### PR TITLE
Add arrow keys and asdf/hjkl keys to operate game

### DIFF
--- a/i_elks.c
+++ b/i_elks.c
@@ -205,16 +205,10 @@ void I_StartTic(void)
 		if (k == 17) // Ctrl + Q
 			I_Quit();
 
-		if ('a' <= k && k <= 'z')
-		{
-			ev.data1 = k;
-			D_PostEvent(&ev);
-		}
-		else
 		{
 			switch (k)
 			{
-				case 27: // Escape
+				case '`': // Real ESC Escape is discarded since prefix for arrow keys
 					ev.data1 = KEYD_START;
 					break;
 				case 13: // Enter
@@ -225,15 +219,27 @@ void I_StartTic(void)
 				//	ev.data1 = KEYD_SPEED;
 				//	break;
 				case '8':
+				case 'k':
+				case 'd':
+				case 'A':
 					ev.data1 = KEYD_UP;
 					break;
 				case '2':
+				case 'j':
+				case 's':
+				case 'B':
 					ev.data1 = KEYD_DOWN;
 					break;
 				case '4':
+				case 'h':
+				case 'a':
+				case 'D':
 					ev.data1 = KEYD_LEFT;
 					break;
 				case '6':
+				case 'l':
+				case 'f':
+				case 'C':
 					ev.data1 = KEYD_RIGHT;
 					break;
 				case 9: // Tab
@@ -257,14 +263,22 @@ void I_StartTic(void)
 				case '=':
 					ev.data1 = KEYD_PLUS;
 					break;
-				case '[':
+				case '{':
 					ev.data1 = KEYD_BRACKET_LEFT;
 					break;
 				case ']':
+				case '}':
 					ev.data1 = KEYD_BRACKET_RIGHT;
 					break;
-				default:
+				case 27:
+				case '[':
+				case '~':
 					ev.data1 = -1;
+					break;
+				default:
+					if ('a' <= k && k <= 'z')
+						ev.data1 = k;
+					else ev.data1 = -1;
 					break;
 			}
 


### PR DESCRIPTION
Hello @FrenkelS,

Are you interested in this? At the price of swapping the ` key for ESC to pause game action, this PR adds up/down/left/right arrow keys to Doom, as well as allowing a/s/d/f and h/j/k/l for easier keyboard operation without using arrow keys. On my macOS laptop, it is much easier to play using hjkl/asdf or arrow keys than to use 2468.

Because the ANSI arrow key sequences contain [, the weapon drop is also changed to {, but in most cases ] (or }) accomplishes the same thing.

The game seems to play well with with ELKS configured for min memory in /bootopts. Using standard out-of-the-box configuration, it seems to run but I ran into a couple of Out of Memory errors, so memory must be tight.

On another note, the compelks.sh script should be mode 755 and a `set -e` added at the top, otherwise compilation errors don't stop the script and new version is silently not created.